### PR TITLE
Use patchEntiry instead of newEntity to pass Application Rules

### DIFF
--- a/src/Model/Behavior/SoftDeleteBehavior.php
+++ b/src/Model/Behavior/SoftDeleteBehavior.php
@@ -50,7 +50,8 @@ class SoftDeleteBehavior extends Behavior {
         if ($this->_config['timestamp'] !== false){
             $delete_data[$this->_config['timestamp']] = $now;
         }
-        $saveEntity = $this->_table->newEntity(
+        $saveEntity = $this->_table->patchEntity(
+            $deleteEntity,
             $delete_data,
             //バリデーションはかけない
             ['validate' => false]


### PR DESCRIPTION
Use `patchEntiry` instead of `newEntity` to pass `Application Rules`
