### PR TITLE
Support CakePHP 3.8 ｜ replace visibleProperties() → getVisible()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/fusic/Reincarnation"
     },
     "require": {
-        "cakephp/cakephp": "^3.4.0"
+        "cakephp/cakephp": "^3.8.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-master",

--- a/src/Model/Behavior/SoftDeleteBehavior.php
+++ b/src/Model/Behavior/SoftDeleteBehavior.php
@@ -100,7 +100,7 @@ class SoftDeleteBehavior extends Behavior {
         }
 
         //アクセス可能なプロパティを見る
-        $properties = $deleteEntity->visibleProperties();
+        $properties = $deleteEntity->getVisible();
         foreach ($properties as $property) {
             //該当プロパティがEntityなら
             //hasone / belongsto /habtmの中間テーブル


### PR DESCRIPTION
## Background
```bash
Deprecated Error: App\Model\Entity\{Entity name}::visibleProperties() is deprecated. Use getVisible() instead. - /var/www/html/app/vendor/fusic/reincarnation/src/Model/Behavior/SoftDeleteBehavior.php, line: 103
```

## TODO
- replace visibleProperties() → getVisible()- replace 
	- ref: https://api.cakephp.org/3.8/class-Cake.Datasource.EntityTrait.html#_visibleProperties
